### PR TITLE
Apply Jekyll theme to GitHub Pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "jekyll", "~> 4.2.0"
+gem "minima", "~> 2.5"

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,3 @@
+theme: minima
+source: docs
+destination: _site

--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -1,0 +1,3 @@
+<footer>
+  <p>&copy; {{ site.time | date: '%Y' }} {{ site.author }}</p>
+</footer>

--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -1,0 +1,4 @@
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{{ page.title }}</title>
+<link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{ page.title }}</title>
+  <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
+</head>
+<body>
+  <header>
+    <h1>{{ site.title }}</h1>
+  </header>
+  <main>
+    {{ content }}
+  </main>
+  <footer>
+    <p>&copy; {{ site.time | date: '%Y' }} {{ site.author }}</p>
+  </footer>
+</body>
+</html>

--- a/docs/_sass/minima.scss
+++ b/docs/_sass/minima.scss
@@ -1,0 +1,8 @@
+/* Minima Theme Styles */
+
+@import "minima/variables";
+@import "minima/mixins";
+@import "minima/base";
+@import "minima/layout";
+@import "minima/syntax-highlighting";
+@import "minima/custom";

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,546 @@
+---
+layout: default
+title: Fabio Calefato's CV
+---
+
+# Fabio Calefato's CV
+
+- Phone: +39 080 571 2213
+- Email: [fabio.calefato@uniba.it](mailto:fabio.calefato@uniba.it)
+- Location: Bari, Italy
+- Website: [collab.di.uniba.it/fabio](https://collab.di.uniba.it/fabio)
+- ORCID: [0000-0003-2654-1588](https://orcid.org/0000-0003-2654-1588)
+- Google Scholar: [n_XWRkoAAAAJ](https://scholar.google.com/citations?user=n_XWRkoAAAAJ)
+- GitHub: [bateman](https://github.com/bateman)
+
+## Current Position
+
+### University of Bari, Dept. of Computer Science, Associate Professor
+
+- Nov 2022 – present
+- Bari, Italy
+- Holds the national habilitation as Full Professor since Dec 2023
+
+### PeoplewareAI s.r.l., Co-founder and CEO
+
+- Feb 2021 – present
+- Bari, Italy
+- [PeoplewareAI](https://peopleware.ai) is a spin-off company of the University of Bari, founded to transfer the results of research in the field of AI and software engineering to the market
+
+## Education
+
+### University of Bari, Italy, **PhD** in **Computer Science**
+
+- Jan 2004 – May 2007
+- *Thesis: ``Supporting Synchronous Communication in Distributed Software Teams''*
+- *Thesis listed among the SIGSOFT Selected Ph.D. Dissertations in the Area of Software Engineering*
+
+### University of Bari, Italy, **MSc** in **Computer Science**
+
+- Sept 1996 – Oct 2002
+- *Thesis: ``P2P Conferences in JXTA''*
+- *Graduation grade: 110/110 with honors*
+
+## Experience
+
+### University of Bari, Dept. of Computer Science, Tenure-track Assistant Professor
+
+- Nov 2019 – Nov 2022
+- Bari, Italy
+
+### University of Bari, Jonian Dept., Untenured Assistant Professor
+
+- Nov 2015 – Nov 2019
+- Taranto, Italy
+
+### University of Bari, Dept. of Computer Science, Postdoctoral Research Fellow
+
+- July 2013 – July 2015
+- Bari, Italy
+
+### University of Bari, Dept. of Computer Science, Postdoctoral Research Fellow
+
+- Apr 2010 – Mar 2013
+- Bari, Italy
+
+### University of Bari, Dept. of Computer Science, Postdoctoral Research Fellow
+
+- Apr 2007 – Nov 2008
+- Bari, Italy
+
+## Bibliometrics
+
+- Google Scholar: *h*-index 30, 3,100+ citations
+- Scopus: *h*-index 21, 1,500+ citations
+
+## Publications
+
+### A multivocal literature review on the benefits and limitations of industry-leading AutoML tools ([10.1016/J.INFSOF.2024.107608](https://doi.org/10.1016/J.INFSOF.2024.107608))
+
+- 2025
+- L. Quaranta, K. Azevedo, ***F. Calefato***, M. Kalinowski
+- Inf. Softw. Technol., vol. 178
+
+### A lot of talk and a badge: An exploratory analysis of personal achievements in GitHub ([10.1016/J.INFSOF.2024.107561](https://doi.org/10.1016/J.INFSOF.2024.107561))
+
+- 2024
+- ***F. Calefato***, L. Quaranta, F. Lanubile
+- Inf. Softw. Technol., vol. 176
+
+### Generative AI in Software Engineering Must Be Human-Centered: The Copenhagen Manifesto ([10.1016/J.JSS.2024.112115](https://doi.org/10.1016/J.JSS.2024.112115))
+
+- 2024
+- D. Russo, S. Baltes, N. Berkel, P. Avgeriou, ***F. Calefato***, B. Cabrero-Daniel, G. Catolino, J. Cito, N. Ernst, T. Fritz, H. Hata, R. Holmes, M. Izadi, F. Khomh, M. Kjærgaard, G. Liebel, A. Lluch-Lafuente, S. Lambiase, W. Maalej, G. Murphy, N. Moe, G. O'Brien, E. Paja, M. Pezzè, J. Persson, R. Prikladnicki, P. Ralph, M. Robillard, T. Silva, K.J. Stol, M.A. Storey, V. Stray, P. Tell, C. Treude, B. Vasilescu
+- J. Syst. Softw., vol. 216
+
+### Pynblint: A quality assurance tool to improve the quality of Python Jupyter notebooks ([10.1016/J.SOFTX.2024.101959](https://doi.org/10.1016/J.SOFTX.2024.101959))
+
+- 2024
+- L. Quaranta, ***F. Calefato***, F. Lanubile
+- SoftwareX, vol. 28
+
+### Continuous Quality Improvement of AI-based Systems: the QualAI Project ([10.1145/3674805.3695393](https://doi.org/10.1145/3674805.3695393))
+
+- 2024
+- N. Novielli, R. Oliveto, F. Palomba, ***F. Calefato***, G. Colavito, V. Martino, A. Porta, G. Giordano, E. Guglielmi, F. Lanubile, L. Quaranta, G. Recupito, S. Scalabrino, A. Spina, A. Vitale
+- Proceedings of the 18th ACM/IEEE International Symposium on Empirical Software Engineering and Measurement, ESEM 2024, Barcelona, Spain, October 24-25, 2024
+
+### Professional Insights into Benefits and Limitations of Implementing MLOps Principles ([10.5220/0012741100003690](https://doi.org/10.5220/0012741100003690))
+
+- 2024
+- G. Araujo, M. Kalinowski, M. Endler, ***F. Calefato***
+- Proceedings of the 26th International Conference on Enterprise Information Systems, ICEIS 2024, Angers, France, April 28-30, 2024, Volume 2
+
+### Toward Collaboration Optimization in Microservice Projects Based on Developer Personalities ([10.1109/ICSA-C63560.2024.00024](https://doi.org/10.1109/ICSA-C63560.2024.00024))
+
+- 2024
+- X. Li, ***F. Calefato***, V. Lenarduzzi, D. Taibi
+- 21st IEEE International Conference on Software Architecture, ICSA 2024 - Companion, Hyderabad, India, June 4-8, 2024
+
+### An MLOps Solution Framework for Transitioning Machine Learning Models into eHealth Systems
+
+- 2024
+- A. Basile, ***F. Calefato***, F. Lanubile, G. Mallardi, L. Quaranta
+- Proceedings of the Ital-IA Intelligenza Artificiale - Thematic Workshops co-located with the 4th CINI National Lab AIIS Conference on Artificial Intelligence (Ital-IA 2024), Naples, Italy, May 29-30, 2024, vol. 3762
+
+### Security Risks and Best Practices of MLOps: A Multivocal Literature Review
+
+- 2024
+- ***F. Calefato***, F. Lanubile, L. Quaranta
+- Proceedings of the 8th Italian Conference on Cyber Security (ITASEC 2024), Salerno, Italy, April 8-12, 2024, vol. 3731
+
+### QualAI: Continuous Quality Improvement of AI-based Systems
+
+- 2024
+- N. Novielli, R. Oliveto, F. Palomba, ***F. Calefato***, G. Colavito, V. Martino, A. Porta, G. Giordano, E. Guglielmi, F. Lanubile, L. Quaranta, G. Recupito, S. Scalabrino, A. Spina, A. Vitale
+- Joint Proceedings of RCIS 2024 Workshops and Research Projects Track co-located with the 18th International Conferecence on Research Challenges in Information Science (RCIS 2024), Guimarães, Portugal, May 14-17, 2024, vol. 3674
+
+### Assessing the Use of AutoML for Data-Driven Software Engineering ([10.1109/ESEM56168.2023.10304796](https://doi.org/10.1109/ESEM56168.2023.10304796))
+
+- 2023
+- ***F. Calefato***, L. Quaranta, F. Lanubile, M. Kalinowski
+- ACM/IEEE International Symposium on Empirical Software Engineering and Measurement, ESEM 2023, New Orleans, LA, USA, October 26-27, 2023
+
+### Will you come back to contribute? Investigating the inactivity of OSS core developers in GitHub ([10.1007/S10664-021-10012-6](https://doi.org/10.1007/S10664-021-10012-6))
+
+- 2022
+- ***F. Calefato***, M. Gerosa, G. Iaffaldano, F. Lanubile, I. Steinmacher
+- Empir. Softw. Eng., vol. 27, no. 3
+
+### Eliciting Best Practices for Collaboration with Computational Notebooks ([10.1145/3512934](https://doi.org/10.1145/3512934))
+
+- 2022
+- L. Quaranta, ***F. Calefato***, F. Lanubile
+- Proc. ACM Hum. Comput. Interact., vol. 6, no. {CSCW1}
+
+### Using Personality Detection Tools for Software Engineering Research: How Far Can We Go? ([10.1145/3491039](https://doi.org/10.1145/3491039))
+
+- 2022
+- ***F. Calefato***, F. Lanubile
+- ACM Trans. Softw. Eng. Methodol., vol. 31, no. 3
+
+### What Makes Agile Software Development Agile? ([10.1109/TSE.2021.3099532](https://doi.org/10.1109/TSE.2021.3099532))
+
+- 2022
+- M. Kuhrmann, P. Tell, R. Hebig, J. Klünder, J. Münch, O. Linssen, D. Pfahl, M. Felderer, C. Prause, S. MacDonell, J. Nakatumba-Nabende, D. Raffo, S. Beecham, E. Tüzün, G. López, N. Paez, D. Fontdevila, S. Licorish, S. Küpper, G. Ruhe, E. Knauss, Ö. Özcan-Top, P. Clarke, F. McCaffery, M. Genero, A. Vizcaíno, M. Piattini, M. Kalinowski, T. Conte, R. Prikladnicki, S. Krusche, A. Coskunçay, E. Scott, ***F. Calefato***, S. Pimonova, R.H. Pfeiffer, U. Schultz, R. Heldal, M. Fazal-Baqaie, C. Anslow, M. Nayebi, K. Schneider, S. Sauer, D. Winkler, S. Biffl, M. Bastarrica, I. Richardson
+- IEEE Trans. Software Eng., vol. 48, no. 9
+
+### Pynblint: a static analyzer for Python Jupyter notebooks ([10.1145/3522664.3528612](https://doi.org/10.1145/3522664.3528612))
+
+- 2022
+- L. Quaranta, ***F. Calefato***, F. Lanubile
+- Proceedings of the 1st International Conference on AI Engineering: Software Engineering for AI, CAIN 2022, Pittsburgh, Pennsylvania, May 16-17, 2022
+
+### A Preliminary Investigation of MLOps Practices in GitHub ([10.1145/3544902.3546636](https://doi.org/10.1145/3544902.3546636))
+
+- 2022
+- ***F. Calefato***, F. Lanubile, L. Quaranta
+- ESEM '22: ACM / IEEE International Symposium on Empirical Software Engineering and Measurement, Helsinki, Finland, September 19 - 23, 2022
+
+### Assessment of off-the-shelf SE-specific sentiment analysis tools: An extended replication study ([10.1007/S10664-021-09960-W](https://doi.org/10.1007/S10664-021-09960-W))
+
+- 2021
+- N. Novielli, ***F. Calefato***, F. Lanubile, A. Serebrenik
+- Empir. Softw. Eng., vol. 26, no. 4
+
+### Global Software Engineering: Challenges and solutions ([10.1016/J.JSS.2020.110887](https://doi.org/10.1016/J.JSS.2020.110887))
+
+- 2021
+- ***F. Calefato***, A. Dubey, C. Ebert, P. Tell
+- J. Syst. Softw., vol. 174
+
+### An In-Depth Analysis of Occasional and Recurring Collaborations in Online Music Co-creation ([10.1145/3493800](https://doi.org/10.1145/3493800))
+
+- 2021
+- ***F. Calefato***, G. Iaffaldano, L. Trisolini, F. Lanubile
+- ACM Trans. Soc. Comput., vol. 4, no. 4
+
+### A Taxonomy of Tools for Reproducible Machine Learning Experiments
+
+- 2021
+- L. Quaranta, ***F. Calefato***, F. Lanubile
+- AIxIA 2021 Discussion Papers co-located with the the 20th International Conference of the Italian Association for Artificial Intelligence (AIxIA2021), Virtual Event, December 1st-3rd, 2021, vol. 3078
+
+### A Virtual Mentor to Support Question-Writing on Stack Overflow ([10.1109/CHASE52884.2021.00027](https://doi.org/10.1109/CHASE52884.2021.00027))
+
+- 2021
+- N. Novielli, ***F. Calefato***, F. Laurentiis, L. Minervini, F. Lanubile
+- 14th IEEE/ACM International Workshop on Cooperative and Human Aspects of Software Engineering, CHASE@ICSE 2021, Madrid, Spain, May 20-21, 2021
+
+### Towards Productizing AI/ML Models: An Industry Perspective from Data Scientists ([10.1109/WAIN52551.2021.00027](https://doi.org/10.1109/WAIN52551.2021.00027))
+
+- 2021
+- F. Lanubile, ***F. Calefato***, L. Quaranta, M. Amoruso, F. Fumarola, M. Filannino
+- 1st IEEE/ACM Workshop on AI Engineering - Software Engineering for AI, WAIN@ICSE 2021, Madrid, Spain, May 30-31, 2021
+
+### KGTorrent: A Dataset of Python Jupyter Notebooks from Kaggle ([10.1109/MSR52588.2021.00072](https://doi.org/10.1109/MSR52588.2021.00072))
+
+- 2021
+- L. Quaranta, ***F. Calefato***, F. Lanubile
+- 18th IEEE/ACM International Conference on Mining Software Repositories, MSR 2021, Madrid, Spain, May 17-19, 2021
+
+### Love, Joy, Anger, Sadness, Fear, and Surprise: SE Needs Special Kinds of AI: A Case Study on Text Mining and SE ([10.1109/MS.2020.2968557](https://doi.org/10.1109/MS.2020.2968557))
+
+- 2020
+- N. Novielli, ***F. Calefato***, F. Lanubile
+- IEEE Softw., vol. 37, no. 3
+
+### A case study on tool support for collaboration in agile development ([10.1145/3372787.3390436](https://doi.org/10.1145/3372787.3390436))
+
+- 2020
+- ***F. Calefato***, A. Giove, F. Lanubile, M. Losavio
+- ICGSE '20: 15th IEEE/ACM International Conference on Global Software Engineering, Seoul, Republic of Korea, June 26-28, 2020
+
+### Can We Use SE-specific Sentiment Analysis Tools in a Cross-Platform Setting? ([10.1145/3379597.3387446](https://doi.org/10.1145/3379597.3387446))
+
+- 2020
+- N. Novielli, ***F. Calefato***, D. Dongiovanni, D. Girardi, F. Lanubile
+- MSR '20: 17th International Conference on Mining Software Repositories, Seoul, Republic of Korea, 29-30 June, 2020
+
+### The Impact of Dynamics of Collaborative Software Engineering on Introverts: A Study Protocol ([10.1145/3379597.3387505](https://doi.org/10.1145/3379597.3387505))
+
+- 2020
+- I. Nunes, C. Treude, ***F. Calefato***
+- MSR '20: 17th International Conference on Mining Software Repositories, Seoul, Republic of Korea, 29-30 June, 2020
+
+### An empirical assessment of best-answer prediction models in technical Q&A sites ([10.1007/S10664-018-9642-5](https://doi.org/10.1007/S10664-018-9642-5))
+
+- 2019
+- ***F. Calefato***, F. Lanubile, N. Novielli
+- Empir. Softw. Eng., vol. 24, no. 2
+
+### A large-scale, in-depth analysis of developers' personalities in the Apache ecosystem ([10.1016/J.INFSOF.2019.05.012](https://doi.org/10.1016/J.INFSOF.2019.05.012))
+
+- 2019
+- ***F. Calefato***, F. Lanubile, B. Vasilescu
+- Inf. Softw. Technol., vol. 114
+
+### RECODE: revision control for digital images ([10.1007/S11042-019-7735-9](https://doi.org/10.1007/S11042-019-7735-9))
+
+- 2019
+- ***F. Calefato***, G. Castellano, V. Rossano
+- Multim. Tools Appl., vol. 78, no. 23
+
+### Correction to: RECODE: revision control for digital images ([10.1007/S11042-019-08458-4](https://doi.org/10.1007/S11042-019-08458-4))
+
+- 2019
+- ***F. Calefato***, G. Castellano, V. Rossano
+- Multim. Tools Appl., vol. 78, no. 23
+
+### Summary of the 14th International Conference on Global Software Engineering (ICGSE) ([10.1145/3356773.3356802](https://doi.org/10.1145/3356773.3356802))
+
+- 2019
+- ***F. Calefato***, P. Tell, A. Dubey
+- ACM SIGSOFT Softw. Eng. Notes, vol. 44, no. 3
+
+### Agile Collaboration for Distributed Teams [Software Technology] ([10.1109/MS.2018.2874668](https://doi.org/10.1109/MS.2018.2874668))
+
+- 2019
+- ***F. Calefato***, C. Ebert
+- IEEE Softw., vol. 36, no. 1
+
+### Why do developers take breaks from contributing to OSS projects?: a preliminary analysis
+
+- 2019
+- G. Iaffaldano, I. Steinmacher, ***F. Calefato***, M. Gerosa, F. Lanubile
+- Proceedings of the 2nd International Workshop on Software Health, SoHeal@ICSE 2019, Montreal, QC, Canada, May 28, 2019
+
+### EMTk: the emotion mining toolkit ([10.1109/SEMOTION.2019.00014](https://doi.org/10.1109/SEMOTION.2019.00014))
+
+- 2019
+- ***F. Calefato***, F. Lanubile, N. Novielli, L. Quaranta
+- Proceedings of the 4th International Workshop on Emotion Awareness in Software Engineering, SEmotion@ICSE 2019, Montreal, QC, Canada, May 28, 2019
+
+### Proceedings of the 14th International Conference on Global Software Engineering, ICGSE 2019, Montreal, QC, Canada, May 25-31, 2019
+
+- 2019
+- ***F. Calefato***, P. Tell, A. Dubey
+- IEEE / ACM
+
+### Sentiment Polarity Detection for Software Development ([10.1007/S10664-017-9546-9](https://doi.org/10.1007/S10664-017-9546-9))
+
+- 2018
+- ***F. Calefato***, F. Lanubile, F. Maiorano, N. Novielli
+- Empir. Softw. Eng., vol. 23, no. 3
+
+### How to ask for technical help? Evidence-based guidelines for writing questions on Stack Overflow ([10.1016/J.INFSOF.2017.10.009](https://doi.org/10.1016/J.INFSOF.2017.10.009))
+
+- 2018
+- ***F. Calefato***, F. Lanubile, N. Novielli
+- Inf. Softw. Technol., vol. 94
+
+### Establishing personal trust-based connections in distributed teams ([10.1002/ITL2.6](https://doi.org/10.1002/ITL2.6))
+
+- 2018
+- ***F. Calefato***, F. Lanubile
+- Internet Technol. Lett., vol. 1, no. 4
+
+### Investigating Crowd Creativity in Online Music Communities ([10.1145/3274296](https://doi.org/10.1145/3274296))
+
+- 2018
+- ***F. Calefato***, G. Iaffaldano, F. Lanubile, F. Maiorano
+- Proc. ACM Hum. Comput. Interact., vol. 2, no. {CSCW}
+
+### Collaboration Success Factors in an Online Music Community ([10.1145/3148330.3148346](https://doi.org/10.1145/3148330.3148346))
+
+- 2018
+- ***F. Calefato***, G. Iaffaldano, F. Lanubile
+- Proceedings of the 2018 ACM Conference on Supporting Groupwork, GROUP 2018, Sanibel Island, FL, USA, January 07 - 10, 2018
+
+### On developers' personality in large-scale distributed projects: the case of the apache ecosystem ([10.1145/3196369.3196372](https://doi.org/10.1145/3196369.3196372))
+
+- 2018
+- ***F. Calefato***, G. Iaffaldano, F. Lanubile, B. Vasilescu
+- Proceedings of the 13th Conference on Global Software Engineering, ICGSE 2018, Gothenburg, Sweden, May 27 - 29, 2018
+
+### Sentiment polarity detection for software development ([10.1145/3180155.3182519](https://doi.org/10.1145/3180155.3182519))
+
+- 2018
+- ***F. Calefato***, F. Lanubile, F. Maiorano, N. Novielli
+- Proceedings of the 40th International Conference on Software Engineering, ICSE 2018, Gothenburg, Sweden, May 27 - June 03, 2018
+
+### A Revision Control System for Image Editing in Collaborative Multimedia Design ([10.1109/IV.2018.00095](https://doi.org/10.1109/IV.2018.00095))
+
+- 2018
+- ***F. Calefato***, G. Castellano, V. Rossano
+- 22nd International Conference Information Visualisation, IV 2018, Fisciano, Italy, July 10-13, 2018
+
+### A gold standard for emotion annotation in stack overflow ([10.1145/3196398.3196453](https://doi.org/10.1145/3196398.3196453))
+
+- 2018
+- N. Novielli, ***F. Calefato***, F. Lanubile
+- Proceedings of the 15th International Conference on Mining Software Repositories, MSR 2018, Gothenburg, Sweden, May 28-29, 2018
+
+### Natural language or not (NLON): a package for software engineering text analysis pipeline ([10.1145/3196398.3196444](https://doi.org/10.1145/3196398.3196444))
+
+- 2018
+- M. Mäntylä, ***F. Calefato***, M. Claes
+- Proceedings of the 15th International Conference on Mining Software Repositories, MSR 2018, Gothenburg, Sweden, May 28-29, 2018
+
+### EmoTxt: A toolkit for emotion recognition from text ([10.1109/ACIIW.2017.8272591](https://doi.org/10.1109/ACIIW.2017.8272591))
+
+- 2017
+- ***F. Calefato***, F. Lanubile, N. Novielli
+- Seventh International Conference on Affective Computing and Intelligent Interaction Workshops and Demos, ACII Workshops 2017, San Antonio, TX, USA, October 23-26, 2017
+
+### A Preliminary Analysis on the Effects of Propensity to Trust in Distributed Software Development ([10.1109/ICGSE.2017.1](https://doi.org/10.1109/ICGSE.2017.1))
+
+- 2017
+- ***F. Calefato***, F. Lanubile, N. Novielli
+- 12th IEEE International Conference on Global Software Engineering, ICGSE 2017, Buenos Aires, Argentina, May 22-23, 2017
+
+### Mining Communication Data in a Music Community: A Preliminary Analysis ([10.1007/978-3-319-74433-9_22](https://doi.org/10.1007/978-3-319-74433-9_22))
+
+- 2017
+- ***F. Calefato***, G. Iaffaldano, F. Lanubile, A. Lategano, N. Novielli
+- Current Trends in Web Engineering - ICWE 2017 International Workshops, Liquid Multi-Device Software and EnWoT, practi-O-web, NLPIT, SoWeMine, Rome, Italy, June 5-8, 2017, Revised Selected Papers, vol. 10544
+
+### Assessing the impact of real-time machine translation on multilingual meetings in global software projects ([10.1007/S10664-015-9372-X](https://doi.org/10.1007/S10664-015-9372-X))
+
+- 2016
+- ***F. Calefato***, F. Lanubile, T. Conte, R. Prikladnicki
+- Empir. Softw. Eng., vol. 21, no. 3
+
+### A University-NGO partnership to sustain assistive technology projects ([10.1145/2883619](https://doi.org/10.1145/2883619))
+
+- 2016
+- ***F. Calefato***, F. Lanubile, R. Nicolo, F. Lippolis
+- Interactions, vol. 23, no. 2
+
+### The EmoQuest Project: Emotions in Q&A Sites ([10.1145/2909132.2926062](https://doi.org/10.1145/2909132.2926062))
+
+- 2016
+- N. Novielli, ***F. Calefato***, F. Lanubile, G. Mininni, A. Taronna
+- Proceedings of the International Working Conference on Advanced Visual Interfaces, AVI 2016, Bari, Italy, June 7-10, 2016
+
+### Moving to Stack Overflow: Best-Answer Prediction in Legacy Developer Forums ([10.1145/2961111.2962585](https://doi.org/10.1145/2961111.2962585))
+
+- 2016
+- ***F. Calefato***, F. Lanubile, N. Novielli
+- Proceedings of the 10th ACM/IEEE International Symposium on Empirical Software Engineering and Measurement, ESEM 2016, Ciudad Real, Spain, September 8-9, 2016
+
+### A Hub-and-Spoke Model for Tool Integration in Distributed Development ([10.1109/ICGSE.2016.12](https://doi.org/10.1109/ICGSE.2016.12))
+
+- 2016
+- ***F. Calefato***, F. Lanubile
+- 11th IEEE International Conference on Global Software Engineering, ICGSE 2016, Orange County, CA, USA, August 2-5, 2016
+
+### Affective trust as a predictor of successful collaboration in distributed software projects ([10.1145/2897000.2897001](https://doi.org/10.1145/2897000.2897001))
+
+- 2016
+- ***F. Calefato***, F. Lanubile
+- Proceedings of the 1st International Workshop on Emotion Awareness in Software Engineering, SEmotion@ICSE 2016, Austin, Texas, USA, May 14-22, 2016
+
+### Proceedings of the 8th International Workshop on Social Software Engineering, SSE 2016, Seattle, WA, USA, November 14, 2016 ([10.1145/2993283](https://doi.org/10.1145/2993283))
+
+- 2016
+- A. Begel, ***F. Calefato***, C. Treude
+- ACM
+
+### The role of social media in affective trust building in customer-supplier relationships ([10.1007/S10660-015-9194-3](https://doi.org/10.1007/S10660-015-9194-3))
+
+- 2015
+- ***F. Calefato***, F. Lanubile, N. Novielli
+- Electron. Commer. Res., vol. 15, no. 4
+
+### Cost Savings in Global Software Engineering: Where's the Evidence? ([10.1109/MS.2015.102](https://doi.org/10.1109/MS.2015.102))
+
+- 2015
+- D. Smite, ***F. Calefato***, C. Wohlin
+- IEEE Softw., vol. 32, no. 4
+
+### Product Line Engineering for NGO Projects ([10.1109/PLEASE.2015.9](https://doi.org/10.1109/PLEASE.2015.9))
+
+- 2015
+- ***F. Calefato***, R. Nicolo, F. Lanubile, F. Lippolis
+- 5th IEEE/ACM International Workshop on Product Line Approaches in Software Engineering, PLEASE 2015, Florence, Italy, May 19, 2015
+
+### Mining Successful Answers in Stack Overflow ([10.1109/MSR.2015.56](https://doi.org/10.1109/MSR.2015.56))
+
+- 2015
+- ***F. Calefato***, F. Lanubile, M. Marasciulo, N. Novielli
+- 12th IEEE/ACM Working Conference on Mining Software Repositories, MSR 2015, Florence, Italy, May 16-17, 2015
+
+### The challenges of sentiment detection in the social programmer ecosystem ([10.1145/2804381.2804387](https://doi.org/10.1145/2804381.2804387))
+
+- 2015
+- N. Novielli, ***F. Calefato***, F. Lanubile
+- Proceedings of the 7th International Workshop on Social Software Engineering, SSE 2015, Bergamo, Italy, September 1, 2015
+
+### Speech Recognition for Voice-Based Machine Translation ([10.1109/MS.2014.14](https://doi.org/10.1109/MS.2014.14))
+
+- 2014
+- T. Duarte, R. Prikladnicki, ***F. Calefato***, F. Lanubile
+- IEEE Softw., vol. 31, no. 1
+
+### An empirical simulation-based study of real-time speech translation for multilingual global project teams ([10.1145/2652524.2652537](https://doi.org/10.1145/2652524.2652537))
+
+- 2014
+- ***F. Calefato***, F. Lanubile, R. Prikladnicki, J. Pinto
+- 2014 ACM-IEEE International Symposium on Empirical Software Engineering and Measurement, ESEM '14, Torino, Italy, September 18-19, 2014
+
+### Investigating the Effect of Social Media on Trust Building in Customer-supplier Relationships ([10.5220/0004905606350642](https://doi.org/10.5220/0004905606350642))
+
+- 2014
+- ***F. Calefato***, F. Lanubile, N. Novielli
+- ICEIS 2014 - Proceedings of the 16th International Conference on Enterprise Information Systems, Volume 2, Lisbon, Portugal, 27-30 April, 2014
+
+### Mobile Speech Translation for Multilingual Requirements Meetings: A Preliminary Study ([10.1109/ICGSE.2014.10](https://doi.org/10.1109/ICGSE.2014.10))
+
+- 2014
+- ***F. Calefato***, F. Lanubile, D. Romita, R. Prikladnicki, J. Pinto
+- IEEE 9th International Conference on Global Software Engineering, ICGSE 2014, Shanghai, China, 18-21 August, 2014
+
+### Towards discovering the role of emotions in stack overflow ([10.1145/2661685.2661689](https://doi.org/10.1145/2661685.2661689))
+
+- 2014
+- N. Novielli, ***F. Calefato***, F. Lanubile
+- Proceedings of the 6th International Workshop on Social Software Engineering, SSE 2014, Hong Kong, China, November 17, 2014
+
+### Group Awareness in Global Software Engineering ([10.1109/MS.2013.30](https://doi.org/10.1109/MS.2013.30))
+
+- 2013
+- F. Lanubile, ***F. Calefato***, C. Ebert
+- IEEE Softw., vol. 30, no. 2
+
+### A Preliminary Investigation of the Effect of Social Media on Affective Trust in Customer-Supplier Relationships ([10.1109/ACII.2013.11](https://doi.org/10.1109/ACII.2013.11))
+
+- 2013
+- ***F. Calefato***, F. Lanubile, N. Novielli
+- 2013 Humaine Association Conference on Affective Computing and Intelligent Interaction, ACII 2013, Geneva, Switzerland, September 2-5, 2013
+
+### Trust in virtual teams: theory and tools ([10.1145/2441955.2442029](https://doi.org/10.1145/2441955.2442029))
+
+- 2013
+- B. Al-Ani, D. Redmiles, C. Souza, R. Prikladnicki, S. Marczak, F. Lanubile, ***F. Calefato***
+- Computer Supported Cooperative Work, CSCW 2013, San Antonio, TX, USA, February 23-27, 2013, Companion Volume
+
+### Can social awareness foster trust building in global software teams? ([10.1145/2501535.2501538](https://doi.org/10.1145/2501535.2501538))
+
+- 2013
+- ***F. Calefato***, F. Lanubile, F. Sportelli
+- Proceedings of the 2013 International Workshop on Social Software Engineering, SSE 2013, Saint Petersburg, Russia, August 18, 2013
+
+### SocialCDE: a social awareness tool for global software teams ([10.1145/2491411.2494592](https://doi.org/10.1145/2491411.2494592))
+
+- 2013
+- ***F. Calefato***, F. Lanubile
+- Joint Meeting of the European Software Engineering Conference and the ACM SIGSOFT Symposium on the Foundations of Software Engineering, ESEC/FSE'13, Saint Petersburg, Russian Federation, August 18-26, 2013
+
+### Computer-mediated communication to support distributed requirements elicitations and negotiations tasks ([10.1007/S10664-011-9179-3](https://doi.org/10.1007/S10664-011-9179-3))
+
+- 2012
+- ***F. Calefato***, D. Damian, F. Lanubile
+- Empir. Softw. Eng., vol. 17, no. 6
+
+### Assessing the impact of real-time machine translation on requirements meetings: a replicated experiment ([10.1145/2372251.2372299](https://doi.org/10.1145/2372251.2372299))
+
+- 2012
+- ***F. Calefato***, F. Lanubile, T. Conte, R. Prikladnicki
+- 2012 ACM-IEEE International Symposium on Empirical Software Engineering and Measurement, ESEM '12, Lund, Sweden - September 19 - 20, 2012
+
+### Social Awareness for Global Software Teams ([10.1109/ICGSE.2012.31](https://doi.org/10.1109/ICGSE.2012.31))
+
+- 2012
+- ***F. Calefato***, F. Lanubile
+- 2012 IEEE Seventh International Conference on Global Software Engineering, Porto Alegre, Rio Grande do Sul, Brazil, August 27-30, 2012
+
+### Augmenting social awareness in a collaborative development environment ([10.1109/CHASE.2012.6223009](https://doi.org/10.1109/CHASE.2012.6223009))
+
+- 2012
+- ***F. Calefato***, F. Lanubile
+- 5th International Workshop on Co-operative and Human Aspects of Software Engineering, CHASE 2012, Zurich, Switzerland, June 2, 2012
+
+### A Controlled Experiment on the Effects of Machine Translation in Multilingual Requirements Meetings ([10.1109/ICGSE.2011.14](https://doi.org/10.1109/ICGSE.2011.14))
+
+- 2011
+- ***F. Calefato***, F. Lanubile, R. Prikladnicki
+- 6th IEEE International Conference on Global Software Engineering, ICGSE 2011, Helsinki, Finland, August 15-18, 2011
+
+### Communication Media Selection for Remote Interaction of Ad Hoc Groups ([10.1016/S0065-2458(10)78006-2](https://doi.org/10.1016/S0065-2458(10)78006-2))
+
+- 2010
+- ***F. Calefato***, F. Lanubile
+- Adv. Comput., vol. 78
+
+### Investigating the use of tags in collaborative development environments:


### PR DESCRIPTION
Apply the `minima` Jekyll theme to the GitHub Pages content stored in the `docs/` folder.

* Add `docs/_config.yml` to configure Jekyll with the `minima` theme.
* Add `docs/_layouts/default.html` to define the default layout for Jekyll pages.
* Add `docs/_includes/head.html` and `docs/_includes/footer.html` for the head and footer includes.
* Add `docs/_sass/minima.scss` to include the SCSS file for the `minima` theme.
* Add `docs/index.md` to convert the static HTML content to Markdown format and set the layout to `default`.
* Add `Gemfile` to include Jekyll and `minima` theme dependencies.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bateman/rendercv-pipeline/pull/1?shareId=256588e9-f331-4337-ad36-11546ae51ebf).